### PR TITLE
Finishing Touches

### DIFF
--- a/crates/bevy_math/src/cubic_splines.rs
+++ b/crates/bevy_math/src/cubic_splines.rs
@@ -1055,7 +1055,7 @@ impl<P: Point> RationalSegment<P> {
 /// A collection of [`RationalSegment`]s chained into a single parametric curve.
 ///
 /// Use any struct that implements the [`RationalGenerator`] trait to create a new curve, such as
-/// [`CubicNURBS`], or convert [`CubicCurve`] using `into/from`.
+/// [`CubicNurbs`], or convert [`CubicCurve`] using `into/from`.
 #[derive(Clone, Debug, PartialEq)]
 pub struct RationalCurve<P: Point> {
     segments: Vec<RationalSegment<P>>,

--- a/crates/bevy_math/src/cubic_splines.rs
+++ b/crates/bevy_math/src/cubic_splines.rs
@@ -1286,7 +1286,7 @@ mod tests {
         assert_eq!(bezier.ease(1.0), 1.0);
     }
 
-    /// Test that RationalCurve properly generalizes CubicCurve. A Cubic upgraded to a rational
+    /// Test that [`RationalCurve`] properly generalizes [`CubicCurve`]. A Cubic upgraded to a rational
     /// should produce pretty much the same output.
     #[test]
     fn cubic_to_rational() {
@@ -1365,7 +1365,7 @@ mod tests {
                 f32::abs(point.length() - 1.0) < EPSILON,
                 "Point {i} is not on the unit circle: {point:?} has length {}",
                 point.length()
-            )
+            );
         }
     }
 }

--- a/crates/bevy_math/src/cubic_splines.rs
+++ b/crates/bevy_math/src/cubic_splines.rs
@@ -1221,7 +1221,8 @@ mod tests {
     use glam::{vec2, Vec2};
 
     use crate::cubic_splines::{
-        CubicBSpline, CubicBezier, CubicGenerator, CubicSegment, RationalCurve,
+        CubicBSpline, CubicBezier, CubicGenerator, CubicNurbs, CubicSegment, RationalCurve,
+        RationalGenerator,
     };
 
     /// How close two floats can be and still be considered equal
@@ -1333,5 +1334,39 @@ mod tests {
         let cubic_accelerations: Vec<_> = b_spline.iter_accelerations(10).collect();
         let rational_accelerations: Vec<_> = rational_b_spline.iter_accelerations(10).collect();
         compare_vectors(cubic_accelerations, rational_accelerations, "acceleration");
+    }
+
+    /// Test that a curbs curve can approximate a portion of a circle.
+    #[test]
+    fn nurbs_circular_arc() {
+        use std::f32::consts::FRAC_PI_2;
+        const EPSILON: f32 = 0.0000001;
+
+        // The following NURBS parameters were determined by constraining the first two
+        // points to the line y=1, the second two points to the line x=1, and the distance
+        // between each pair of points to be equal. One can solve the weights by assuming the
+        // first and last weights to be one, the intermediate weights to be equal, and
+        // subjecting ones self to a lot of tedious matrix algebra.
+
+        let alpha = FRAC_PI_2;
+        let leg = 2.0 * f32::sin(alpha / 2.0) / (1.0 + 2.0 * f32::cos(alpha / 2.0));
+        let weight = (1.0 + 2.0 * f32::cos(alpha / 2.0)) / 3.0;
+        let points = [
+            vec2(1.0, 0.0),
+            vec2(1.0, leg),
+            vec2(leg, 1.0),
+            vec2(0.0, 1.0),
+        ];
+        let weights = [1.0, weight, weight, 1.0];
+        let knots = [0.0, 0.0, 0.0, 0.0, 1.0, 1.0, 1.0, 1.0];
+        let spline = CubicNurbs::new(points, Some(weights), Some(knots)).unwrap();
+        let curve = spline.to_curve();
+        for (i, point) in curve.iter_positions(10).enumerate() {
+            assert!(
+                f32::abs(point.length() - 1.0) < EPSILON,
+                "Point {i} is not on the unit circle: {point:?} has length {}",
+                point.length()
+            )
+        }
     }
 }

--- a/crates/bevy_math/src/cubic_splines.rs
+++ b/crates/bevy_math/src/cubic_splines.rs
@@ -1167,9 +1167,8 @@ impl<P: Point> RationalCurve<P> {
                     // of NURBS curves and surfaces" by Choi et al. or equation 3 from "General Matrix
                     // Representations for B-Splines" by Qin.
                     return (segment, t / segment.knot_span);
-                } else {
-                    t -= segment.knot_span;
                 }
+                t -= segment.knot_span;
             }
             return (self.segments.last().unwrap(), 1.0);
         }

--- a/crates/bevy_math/src/cubic_splines.rs
+++ b/crates/bevy_math/src/cubic_splines.rs
@@ -1221,8 +1221,7 @@ mod tests {
     use glam::{vec2, Vec2};
 
     use crate::cubic_splines::{
-        CubicBSpline, CubicBezier, CubicGenerator, CubicNurbs, CubicSegment, RationalCurve,
-        RationalGenerator,
+        CubicBSpline, CubicBezier, CubicGenerator, CubicSegment, RationalCurve,
     };
 
     /// How close two floats can be and still be considered equal
@@ -1334,34 +1333,5 @@ mod tests {
         let cubic_accelerations: Vec<_> = b_spline.iter_accelerations(10).collect();
         let rational_accelerations: Vec<_> = rational_b_spline.iter_accelerations(10).collect();
         compare_vectors(cubic_accelerations, rational_accelerations, "acceleration");
-    }
-
-    /// Test that a curbs curve can approximate a portion of a circle.
-    #[test]
-    fn nurbs_circular_arc() {
-        use std::f32::consts::SQRT_2;
-        const EPSILON: f32 = 0.1;
-        // It's not an especially precise approximation because all our nurbs are cubic.
-        // A quadratic or quintic curve rational would be exact. it just needs to be better
-        // than a raw B-spline.
-
-        let points = [
-            vec2(1.0, 0.0),
-            vec2(1.0, 1.0),
-            vec2(0.0, 1.0),
-            vec2(-1.0, 1.0),
-            vec2(-1.0, 0.0),
-        ];
-
-        let weights = vec![1., SQRT_2 / 2., 1., SQRT_2 / 2., 1.];
-        let spline = CubicNurbs::new(points, Some(weights), None as Option<Vec<f32>>).unwrap();
-        let curve = spline.to_curve();
-        for (i, point) in curve.iter_positions(10).enumerate() {
-            assert!(
-                point.length() - 1.0 < EPSILON,
-                "Point {i} is not on the unit circle: {point:?} has length {}",
-                point.length()
-            )
-        }
     }
 }


### PR DESCRIPTION
+ Re-touched a bunch of the other spline docs so they all agree and use the same style. I don't think Alice will mind doing this here, as she was asking for docs on some stuff already not touched by this PR (like the characteristic matrix of a normal BSpline).
+ I replaced all "Knot Vector" and "Weight Vector" language with "knots" and "weights". Less verbose.
+ Knots are now normalized such that the intervals between knots form an exact cover of `[0, N]` where `N` is the number of curves. This makes both nurbs and b-splines have the same parametric domain.
+ `RationalSegement` now tracks the size of it's parametric domain, as derived from the knot vector.
+ `RationalCurve` now allows for different sizes of segment, and clamps the parameter to the curve domain. The output of `RationalCurve::segment` is mapped to `[0, 1]`.
+ Added detailed references to the papers where possible.